### PR TITLE
Update runtime to 22.08

### DIFF
--- a/com.dosbox_x.DOSBox-X.yaml
+++ b/com.dosbox_x.DOSBox-X.yaml
@@ -1,7 +1,7 @@
 ---
 app-id: com.dosbox_x.DOSBox-X
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 
 command: dosbox-x
@@ -55,6 +55,7 @@ modules:
       - --enable-core-inline
       - --enable-debug=heavy
       - --enable-sdl2
+      - --disable-avcodec
     sources:
       - type: git
         url: https://github.com/joncampbell123/dosbox-x

--- a/com.dosbox_x.DOSBox-X.yaml
+++ b/com.dosbox_x.DOSBox-X.yaml
@@ -53,7 +53,6 @@ modules:
     buildsystem: autotools
     config-opts:
       - --enable-core-inline
-      - --enable-debug=heavy
       - --enable-sdl2
       - --disable-avcodec
     sources:


### PR DESCRIPTION
Disable FFMPEG recording, the required version is too old.

One can use OBS if screen recording is needed.