### PR TITLE
Bump version to match the installed DOSBox-X version

### DIFF
--- a/com.dosbox_x.DOSBox-X.metainfo.xml
+++ b/com.dosbox_x.DOSBox-X.metainfo.xml
@@ -11,7 +11,7 @@
     <category>Game</category>
   </categories>
   <releases>
-          <release version="2024.03.01" date="2024-3-1"/>
+          <release version="2024.07.01" date="2024-7-1"/>
   </releases>
   <screenshots>
 	  <screenshot type="default">


### PR DESCRIPTION
A while back, the DOSBox-X version was bumped from 2024-03-01 to 2024-07-01, but the metainfo version wasn't adjusted to reflect the installed version. I only noticed when the title bar:

![image](https://github.com/user-attachments/assets/f6f0685c-256f-4d91-8d5f-40edb1109325)

Didn't match the output of `flatpak info`:

```
DOSBox-X - x86/DOS emulator with sound and graphics

          ID: com.dosbox_x.DOSBox-X
         Ref: app/com.dosbox_x.DOSBox-X/x86_64/stable
        Arch: x86_64
      Branch: stable
     Version: 2024.03.01
```

This change bumps the version, and nothing else.